### PR TITLE
[FE] ✨ PageTitle 컴포넌트 구현

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import Link from 'next/link';
 import '@/styles/globals.css';
-import Logo from '@/components/common/Logo';
 
 const galmuri = localFont({
   src: [
@@ -72,9 +71,6 @@ export default function RootLayout({
             <Link href="/post/edit/1">게시글 편집</Link>
           </li>
         </ul>
-        <Logo size="small" />
-        <Logo size="medium" />
-        <Logo size="large" />
       </body>
     </html>
   );

--- a/client/src/components/common/PageTitle.tsx
+++ b/client/src/components/common/PageTitle.tsx
@@ -1,0 +1,13 @@
+import { DefaultProps } from '@/types/common';
+
+interface PageTitleProps extends DefaultProps {
+  text: string;
+}
+
+export default function PageTitle({ text }: PageTitleProps) {
+  return (
+    <div className="mx-auto px-[12px] py-[20px] bg-[url('/assets/img/bg_wood_dark.png')] bg-contain bg-repeat border-[3px] border-brown-70 rounded-lg text-center text-[1.75rem] font-bold text-brown-10 ">
+      {text}
+    </div>
+  );
+}


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [ ] ADD : 에셋 파일 추가
- [ ] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [ ] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CONF: 빌드, 환경 설정
- [ ] CHORE: 기타 작업

## Abstracts
* PageTitle 컴포넌트를 구현했습니다.

## Description
* string 타입의 text만 전달받아 화면에 렌더링 됩니다.


<img src="https://github.com/codestates-seb/seb45_main_011/assets/44600584/13cd807d-0bf4-4a00-8be7-3b6fbc8c4f67" width="200" height="150">

---
Close #44
