### PR TITLE
[BE] 식물 일지 CRUD 기능 구현

### DIFF
--- a/server/src/main/java/com/growstory/domain/account/service/AccountService.java
+++ b/server/src/main/java/com/growstory/domain/account/service/AccountService.java
@@ -133,7 +133,7 @@ public class AccountService {
 
         // 사용자가 인증되지 않거나 익명인지 확인하고 그렇다면 401 예외 던지기
         if (authentication.getName() == null || authentication.getName().equals("anonymousUser")) {
-            throw new BusinessLogicException(ExceptionCode.ACCOUNT_UNAUTHORIZED);   // 🚨 예외처리
+            throw new BusinessLogicException(ExceptionCode.ACCOUNT_UNAUTHORIZED);
         }
 
         // 사용자가 일치하지 않으면 405 예외 던지기

--- a/server/src/main/java/com/growstory/domain/board/service/BoardService.java
+++ b/server/src/main/java/com/growstory/domain/board/service/BoardService.java
@@ -10,6 +10,7 @@ import com.growstory.domain.hashTag.service.HashTagService;
 import com.growstory.domain.images.service.BoardImageService;
 import com.growstory.domain.leaf.entity.Leaf;
 import com.growstory.domain.leaf.repository.LeafRepository;
+import com.growstory.global.auth.utils.AuthUserUtils;
 import com.growstory.global.exception.BusinessLogicException;
 import com.growstory.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
@@ -30,10 +31,11 @@ public class BoardService {
     private final AccountService accountService;
     private final HashTagService hashTagService;
     private final BoardImageService boardImageService;
+    private final AuthUserUtils authUserUtils;
 
     public ResponseBoardDto createBoard(Long leafId, RequestBoardDto.Post requestBoardDto, MultipartFile image) {
         //TODO: accountService로직 변경으로 인한 수정 필요
-        Account findAccount = accountService.findVerifiedAccount();
+        Account findAccount = authUserUtils.getAuthUser();
 
         boardImageService.saveBoardImage(image);
 
@@ -77,7 +79,7 @@ public class BoardService {
     }
 
     public void modifyBoard(Long boardId, RequestBoardDto.Patch requestBoardDto, MultipartFile image) {
-        Account findBoard = accountService.findVerifiedAccount();
+        Account findBoard = authUserUtils.getAuthUser();
 
 //        Leaf findLeaf = leafRepository.findById(leafId)
 //                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.LEAF_NOT_FOUND));

--- a/server/src/main/java/com/growstory/domain/images/entity/JournalImage.java
+++ b/server/src/main/java/com/growstory/domain/images/entity/JournalImage.java
@@ -16,7 +16,7 @@ import javax.persistence.*;
 public class JournalImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long journalImage;
+    private long journalImageId;
 
     @Column(name = "ORIGIN_NAME", nullable = false)
     private String originName;
@@ -24,8 +24,14 @@ public class JournalImage {
     @Column(name = "IMAGE_URL", nullable = false)
     private String imageUrl;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "JOURNAL_ID", nullable = false)
     private Journal journal;
 
+    public void updateJournal(Journal journal) {
+        this.journal = journal;
+        if(journal.getJournalImage()!=this) {
+            journal.updateImg(this);
+        }
+    }
 }

--- a/server/src/main/java/com/growstory/domain/images/repository/JournalImageRepository.java
+++ b/server/src/main/java/com/growstory/domain/images/repository/JournalImageRepository.java
@@ -1,0 +1,7 @@
+package com.growstory.domain.images.repository;
+
+import com.growstory.domain.images.entity.JournalImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JournalImageRepository extends JpaRepository<JournalImage, Long> {
+}

--- a/server/src/main/java/com/growstory/domain/images/service/JournalImageService.java
+++ b/server/src/main/java/com/growstory/domain/images/service/JournalImageService.java
@@ -1,0 +1,56 @@
+package com.growstory.domain.images.service;
+
+import com.growstory.domain.images.entity.JournalImage;
+import com.growstory.domain.images.repository.JournalImageRepository;
+import com.growstory.domain.journal.entity.Journal;
+import com.growstory.global.aws.service.S3Uploader;
+import com.growstory.global.exception.BusinessLogicException;
+import com.growstory.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class JournalImageService {
+
+    private final JournalImageRepository journalImageRepository;
+    private final S3Uploader s3Uploader;
+
+    // 테이블 인스턴스 생성 및 S3 파일 업로드
+    public JournalImage createJournalImgWithS3(MultipartFile image, String type, Journal journal) {
+        String imgUrl = s3Uploader.uploadImageToS3(image, type);
+        JournalImage journalImage =
+                JournalImage.builder()
+                        .imageUrl(imgUrl)
+                        .originName(image.getOriginalFilename())
+                        .journal(journal)
+                        .build();
+        return journalImageRepository.save(journalImage);
+    }
+
+    // 테이블 인스턴스 삭제 및 S3 데이터 삭제
+    public void deleteJournalImageWithS3(JournalImage journalImage, String type) {
+        if(journalImage == null) return;
+
+        //TODO: 오류가 없는데 journalImageRepository.deleteById(id); 로직이 전혀 동작하지 않음.
+//        long id = journalImage.getJournalImageId();
+        journalImageRepository.delete(journalImage);
+//        journalImageRepository.deleteById(id);
+
+        Journal journal = journalImage.getJournal();
+        journal.removeJournalImage(journalImage);
+
+        s3Uploader.deleteImageFromS3(journalImage.getImageUrl(), type);
+    }
+
+    public JournalImage findVerifiedImg(long journalImageId) {
+       return journalImageRepository.findById(journalImageId).orElseThrow(
+               ()-> new BusinessLogicException(ExceptionCode.JOURNAL_IMG_NOT_FOUND)
+       );
+    }
+
+
+}

--- a/server/src/main/java/com/growstory/domain/journal/controller/JournalController.java
+++ b/server/src/main/java/com/growstory/domain/journal/controller/JournalController.java
@@ -1,0 +1,70 @@
+package com.growstory.domain.journal.controller;
+
+import com.growstory.domain.journal.dto.JournalDto;
+import com.growstory.domain.journal.service.JournalService;
+import com.growstory.global.response.SingleResponseDto;
+import com.growstory.global.utils.UriCreator;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/leaves")
+@Validated
+public class JournalController {
+
+    private final JournalService journalService;
+
+    private static final String DEFAULT_URL = "http://localhost8080/v1/leaves";
+
+    public JournalController(JournalService journalService) {
+        this.journalService = journalService;
+    }
+
+    @GetMapping("/{leaf-id}/journals")
+    public ResponseEntity<SingleResponseDto> getJournals(@Positive  @PathVariable("leaf-id") Long leafId) {
+
+        List<JournalDto.Response> journals = journalService.findAllJournals(leafId);
+
+        return ResponseEntity.ok().body(SingleResponseDto.builder()
+                .status(HttpStatus.OK.value())
+                .message(HttpStatus.OK.getReasonPhrase())
+                .data(journals).build());
+    }
+
+    @PostMapping("/{leaf-id}/journals")
+    public ResponseEntity<HttpStatus> postJournal(@Positive @PathVariable("leaf-id") Long leafId,
+                                                  @Valid @RequestPart JournalDto.Post postDto,
+                                                  @RequestPart(required = false) MultipartFile image) {
+        JournalDto.Response journal = journalService.createJournal(leafId, postDto, image);
+
+        URI location = UriCreator.createUri(DEFAULT_URL, journal.getJournalId());
+
+        return ResponseEntity.created(location).build();
+    }
+
+    @PatchMapping("/journals/{journal-id}")
+    public ResponseEntity<HttpStatus> patchJournal(@Positive Long accountId,
+                                                   @Positive @PathVariable("journal-id") Long journalId,
+                                                   @Valid @RequestPart JournalDto.Patch patchDto,
+                                                   @RequestPart(required = false) MultipartFile image) {
+
+        journalService.updateJournal(accountId, journalId, patchDto, image);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/journals/{journal-id}")
+    public ResponseEntity<HttpStatus> deleteJournal(@Positive @PathVariable("journal-id") Long journalId) {
+        journalService.deleteJournal(journalId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/server/src/main/java/com/growstory/domain/journal/dto/JournalDto.java
+++ b/server/src/main/java/com/growstory/domain/journal/dto/JournalDto.java
@@ -1,0 +1,33 @@
+package com.growstory.domain.journal.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public class JournalDto {
+    @Getter
+    public static class Post {
+        @NotBlank
+        String title;
+        @NotBlank
+        String content;
+    }
+
+    @Getter
+    public static class Patch {
+        String title;
+        String content;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        long journalId;
+        String title;
+        String content;
+        String imageUrl;
+    }
+}

--- a/server/src/main/java/com/growstory/domain/journal/entity/Journal.java
+++ b/server/src/main/java/com/growstory/domain/journal/entity/Journal.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.List;
 
 @Entity
 @Getter
@@ -24,15 +23,39 @@ public class Journal extends BaseTimeEntity {
 
     private String title;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String content;
 
-    private String imageUrl;
+    @OneToOne(mappedBy = "journal", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    private JournalImage journalImage;
 
     @ManyToOne
     @JoinColumn(name = "LEAF_ID")
     private Leaf leaf;
 
-    @OneToMany(mappedBy = "journal")
-    private List<JournalImage> journalImage;
+    public void updateImg(JournalImage journalImage) {
+        this.journalImage=journalImage;
+        if(journalImage.getJournal()!=this) {
+            journalImage.updateJournal(this);
+        }
+    }
+
+    public void updateLeaf(Leaf findLeaf) {
+        this.leaf=findLeaf;
+//        if(!findLeaf.getJournals().contains(this)) {
+//            findLeaf.getJournals().add(this);
+//        }
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void removeJournalImage(JournalImage journalImage) {
+        this.journalImage = null;
+    }
 }

--- a/server/src/main/java/com/growstory/domain/journal/mapper/JournalMapper.java
+++ b/server/src/main/java/com/growstory/domain/journal/mapper/JournalMapper.java
@@ -1,0 +1,41 @@
+package com.growstory.domain.journal.mapper;
+
+import com.growstory.domain.board.entity.Board;
+import com.growstory.domain.journal.dto.JournalDto;
+import com.growstory.domain.journal.entity.Journal;
+import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.ManyToOne;
+
+@Component
+public class JournalMapper {
+    public JournalDto.Response toResponseFrom(Journal journal) {
+        String imgUrl = journal.getJournalImage() == null ?
+                null : journal.getJournalImage().getImageUrl();
+
+        return JournalDto.Response
+                .builder()
+                .journalId(journal.getJournalId())
+                .title(journal.getTitle())
+                .content(journal.getContent())
+                .imageUrl(imgUrl) //nullable
+                .build();
+    }
+
+//    public Journal toEntityFrom(JournalDto.Post postDto) {
+//        return Journal.builder()
+//                .title(postDto.getTitle())
+//                .content(postDto.getContent())
+//                .isConnectedToBoard(postDto.isConnectedToBoard())
+//                .build();
+//    }
+
+    public Board convertToBoard(Journal journal) {
+        return Board.builder()
+                .title(journal.getTitle())
+                .content(journal.getContent())
+                .account(journal.getLeaf().getAccount())
+                .build();
+    }
+}

--- a/server/src/main/java/com/growstory/domain/journal/repository/JournalRepository.java
+++ b/server/src/main/java/com/growstory/domain/journal/repository/JournalRepository.java
@@ -1,0 +1,7 @@
+package com.growstory.domain.journal.repository;
+
+import com.growstory.domain.journal.entity.Journal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JournalRepository extends JpaRepository<Journal,Long> {
+}

--- a/server/src/main/java/com/growstory/domain/journal/service/JournalService.java
+++ b/server/src/main/java/com/growstory/domain/journal/service/JournalService.java
@@ -1,0 +1,120 @@
+package com.growstory.domain.journal.service;
+
+import com.growstory.domain.account.service.AccountService;
+import com.growstory.domain.images.entity.JournalImage;
+import com.growstory.domain.images.service.JournalImageService;
+import com.growstory.domain.journal.dto.JournalDto;
+import com.growstory.domain.journal.entity.Journal;
+import com.growstory.domain.journal.mapper.JournalMapper;
+import com.growstory.domain.journal.repository.JournalRepository;
+import com.growstory.domain.leaf.entity.Leaf;
+import com.growstory.domain.leaf.service.LeafService;
+import com.growstory.global.aws.service.S3Uploader;
+import com.growstory.global.exception.BusinessLogicException;
+import com.growstory.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class JournalService {
+
+    private final JournalRepository journalRepository;
+    private final JournalImageService journalImageService;
+    private final LeafService leafService;
+    private final JournalMapper journalMapper;
+    private final S3Uploader s3Uploader;
+    private final AccountService accountService;
+
+    private static final String JOURNAL_IMAGE_PROCESS_TYPE = "journal_image";
+
+    @Transactional(readOnly = true)
+    public List<JournalDto.Response> findAllJournals(Long leafId) {
+        Leaf leaf = leafService.findLeafEntityWithNoAuth(leafId);
+        return leaf.getJournals().stream()
+                .map(journalMapper::toResponseFrom)
+                .collect(Collectors.toList());
+    }
+
+    public JournalDto.Response createJournal(Long leafId, JournalDto.Post postDto, MultipartFile image) {
+        Leaf findLeaf = leafService.findLeafEntityBy(leafId);
+        Journal journal = createJournalWithNoImg(findLeaf, postDto);
+        //image가 null일 경우
+        if(image==null|| image.isEmpty()) {
+            return journalMapper.toResponseFrom(journal);
+        }
+        //image가 null이 아닐 경우 이미지 업로드 및 DB 저장
+        JournalImage savedJournalImage = journalImageService.createJournalImgWithS3(image, JOURNAL_IMAGE_PROCESS_TYPE, journal);
+//        image 정보 Journal에 업데이트
+        journal.updateImg(savedJournalImage);
+
+        return journalMapper.toResponseFrom(journalRepository.save(journal));
+    }
+
+    private Journal createJournalWithNoImg(Leaf findLeaf, JournalDto.Post postDto) {
+        return journalRepository.save(Journal.builder()
+                .title(postDto.getTitle())
+                .content(postDto.getContent())
+                .leaf(findLeaf)
+                .journalImage(null)
+                .build());
+    }
+
+    public void updateJournal(Long accountId, Long journalId, JournalDto.Patch patchDto, MultipartFile image) {
+        accountService.isAuthIdMatching(accountId);
+        Journal findJournal = findVerifiedJournalBy(journalId);
+
+        Optional.ofNullable(patchDto.getTitle())
+                .ifPresent(findJournal::updateTitle);
+        Optional.ofNullable(patchDto.getContent())
+                .ifPresent(findJournal::updateContent);
+
+        updateLoadImage(image, findJournal, JOURNAL_IMAGE_PROCESS_TYPE);
+    }
+
+    //TODO: S3Uploader로 빼는 리팩토링 작업? (상위 클래스 Image를 이용한 형변환)
+    // 기존 DB와 S3에 저장된 이미지 정보를 업로드 이미지 여부에 따라 수정
+    private void updateLoadImage(MultipartFile image, Journal journal, String type) {
+        JournalImage journalImage = journal.getJournalImage();
+        if (image == null || image.isEmpty()) { //전송 이미지가 없을 경우
+            if (journalImage != null) {
+                // 업로드 이미지가 전송되지 않은 경우 테이블 삭제 및 기존 S3에서 해당 파일 삭제
+                journalImageService.deleteJournalImageWithS3(journalImage, type);
+            }
+            // 수정 요청 이미지가 null 또는 empty이면 값을 수정하지 않는다.
+            return;
+        }
+        // (image != null && !image.isEmpty()) : 업로드 이미지가 전송된 경우
+        if (journalImage != null) { // 기존 이미지가 존재하는 경우
+            //TODO: 기존 이미지와 일치하는지 비교 후 삭제하고 싶은데 방법이 없을까? (원본이름 또는 URL의 비교?)
+            // 원본 이름은 비교하는 의미가 없고, URL은 UUID를 통한 변화한 이름이 포함되기 때문에 비교 불가능.
+            // 클라이언트에서 이미지 수정을 하지 않으면 image를 null 또는 isEmpty() 형태로 보내주면 되겠구나! -> 애초에 수정한 게시물만 이 단계로 오게된다.
+
+            // 업로드 이미지가 전송된 경우 기존 이미지 삭제 후 재업로드
+            journalImageService.deleteJournalImageWithS3(journalImage, type);
+        }
+        // 업로드 이미지가 존재하면 JournalImage DB에 업데이트 이후 S3에 업로드한다.
+        journalImageService.createJournalImgWithS3(image, type, journal);
+    }
+
+    public void deleteJournal(Long journalId) {
+        Journal journal = findVerifiedJournalBy(journalId);
+        //TODO: 저널에 딸린 이미지들도 S3에서 삭제해야 한다.
+        JournalImage journalImage = journal.getJournalImage();
+        journalImageService.deleteJournalImageWithS3(journalImage, JOURNAL_IMAGE_PROCESS_TYPE);
+        journalRepository.delete(journal);
+    }
+
+    private Journal findVerifiedJournalBy(Long journalId) {
+        return journalRepository.findById(journalId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.JOURNAL_NOT_FOUND));
+    }
+
+}

--- a/server/src/main/java/com/growstory/domain/leaf/service/LeafService.java
+++ b/server/src/main/java/com/growstory/domain/leaf/service/LeafService.java
@@ -72,6 +72,11 @@ public class LeafService {
         return getLeafResponseDto(findVerifiedLeaf(findAccount.getAccountId(), leafId));
     }
 
+    public Leaf findLeafEntityWithNoAuth(Long leafId) {
+        return leafRepository.findById(leafId).orElseThrow(() ->
+                    new BusinessLogicException(ExceptionCode.LEAF_NOT_FOUND));
+    }
+
     public Leaf findLeafEntityBy(Long leafId) {
         Account findAccount = authUserUtils.getAuthUser();
         Leaf findLeaf = findVerifiedLeaf(findAccount.getAccountId(), leafId);

--- a/server/src/main/java/com/growstory/domain/plant_object/dto/PlantObjDto.java
+++ b/server/src/main/java/com/growstory/domain/plant_object/dto/PlantObjDto.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Getter
@@ -20,8 +22,11 @@ public class PlantObjDto {
     @Builder
     // 오브젝트 구입 시 입력 Dto
     public static class Post {
+        @NotBlank
         private String nickName;
+        @NotBlank
         private LocationDto.Post locationDto;
+        @NotBlank
         private Long leafId;
     }
 
@@ -32,6 +37,7 @@ public class PlantObjDto {
     @Builder
     public static class PatchLocation {
        private Long plantObjId;
+       @NotBlank
        private LocationDto.Patch locationDto;
     }
 

--- a/server/src/main/java/com/growstory/global/aws/service/S3Uploader.java
+++ b/server/src/main/java/com/growstory/global/aws/service/S3Uploader.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.UUID;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class S3Uploader {
     private final AmazonS3 amazonS3;

--- a/server/src/main/java/com/growstory/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/growstory/global/exception/ExceptionCode.java
@@ -24,6 +24,7 @@ public enum ExceptionCode {
     JOURNAL_NOT_FOUND(404, "Journal not found"),
     JOURNAL_NOT_ALLOW(405, "Journal doesn't match the author"),
     JOURNAL_EXISTS(409, "Journal already Exists"),
+    JOURNAL_IMG_NOT_FOUND(404, "Journal Image not found"),
 
     POINT_TYPE_NOT_FOUND(404, "Earn point type not found."),
 


### PR DESCRIPTION
## Title
- [BE] 식물 일지 CRUD 기능 구현

## PR Type
- [x] FEAT: 새로운 기능 구현
- [ ] ADD : 에셋 파일 추가
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CONF: 빌드, 환경 설정
- [x] CHORE: 기타 작업

## Abstracts
- 식물 일지 관련 CRUD 기능 구현
- DB와 S3 데이터 간 불일치 버그 픽스
- 불필요한 로직 개선

## Description
![image](https://github.com/codestates-seb/seb45_main_011/assets/124790177/a30499b1-3c36-4448-b75b-668a24c72827)


## Discussion
- JournalImage만 단독으로 삭제했을 경우 DB 데이터가 삭제되지 않는 이상 현상 개선 필요
- 응답 데이터 재논의 필요

---
Close #94 
(작성한 Issue를 연결해주세요.)
